### PR TITLE
Add InsightFace REST entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@
 
 ![amd64][amd64-shield]
 
+### [InsightFace REST](./insightface-rest)
+
+![amd64][amd64-shield] ![aarch64][aarch64-shield]
+
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg


### PR DESCRIPTION
## Summary
- add InsightFace REST to the Detector Add-ons section

## Testing
- `npm ci` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_68517fe6f1e88321a3466c6e3c982cc6